### PR TITLE
Init the t0 config role support with platform support

### DIFF
--- a/ptf/platform_helper/brcm_t0_sai_helper.py
+++ b/ptf/platform_helper/brcm_t0_sai_helper.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021 Microsoft Open Technologies, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+#    THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+#    CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+#    LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+#    FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+#
+#    See the Apache Version 2.0 License for specific language governing
+#    permissions and limitations under the License.
+#
+#    Microsoft would like to thank the following companies for their review and
+#    assistance with these files: Intel Corporation, Mellanox Technologies Ltd,
+#    Dell Products, L.P., Facebook, Inc., Marvell International Ltd.
+
+"""
+This file contains class for brcm specified functions.
+"""
+
+from platform_helper.common_sai_helper import * # pylint: disable=wildcard-import; lgtm[py/polluting-import]
+
+import pdb
+class BrcmT0SaiHelper(CommonSaiHelper):
+    """
+    This class contains broadcom(brcm) specified functions for the platform setup and test context configuration.
+    """
+
+    platform = 'brcm'
+    role_config = 't0'
+
+    def normal_setup(self):
+        """
+        Setup method
+        """
+        print("BrcmT0SaiHelper::normal_setup")
+        self.start_switch()
+        self.config_meta_port()
+
+
+    def config_meta_port(self):
+        """
+        Entry point for configuring the meta and port configs.
+        """
+        attr = sai_thrift_get_switch_attribute(self.client, default_virtual_router_id=True)
+        self.default_vrf = attr['default_virtual_router_id']
+        self.assertNotEqual(self.default_vrf, 0)
+        pdb.set_trace()
+
+
+    def start_switch(self):
+        """
+        Start switch and wait seconds for a warm up.
+        """
+        switch_init_wait = 1
+
+        self.switch_id = sai_thrift_create_switch(
+            self.client, init_switch=True, src_mac_address=ROUTER_MAC)
+        self.assertEqual(self.status(), SAI_STATUS_SUCCESS)
+
+        print("Waiting for switch to get ready, {} seconds ...".format(switch_init_wait))
+        time.sleep(switch_init_wait)

--- a/ptf/sai_t0_case.py
+++ b/ptf/sai_t0_case.py
@@ -1,0 +1,26 @@
+from sai_thrift.sai_headers import *
+from sai_base_test import *
+
+class InitBasicData(PlatformSaiHelper):
+    """
+    This is a test class use to trigger some basic verification when set up the basic t0 data configuration.
+    """
+    #Todo remove this class when T0 data is ready, this class should not be checked into repo
+    def setUp(self):
+        """
+        Test the basic setup proecss
+        """
+        #this process contains the switch_init process
+        SaiHelperBase.setUp(self)
+
+    def runTest(self):
+        """
+        Test the basic runTest proecss
+        """
+        pass
+
+    def tearDown(self):
+        """
+        Test the basic tearDown proecss
+        """
+        pass


### PR DESCRIPTION
In order to use the different role on different platform, add the role support parameter.
By using this parameters, we can select the target role config on a platform.

change details:
Refactor the structure in the base_test_class, then we can use a automatically way to select the platform and t0.
Add a role config 'T0' on broadcom platform.
Add a basic test case, which can illustrate how to use that config parameters and use to verify the t0 config.
Add the emppty method which will be used to make the basic t0 config.

sample command
ptf --test-dir /tmp/SAI/ptf sai_t0_case.InitBasicData --interface
'0-0@eth0' --interface '0-1@eth1' --interface '0-2@eth2' --interface
'0-3@eth3' --interface '0-4@eth4' --interface '0-5@eth5' --interface
'0-6@eth6' --interface '0-7@eth7' --interface '0-8@eth8' --interface
'0-9@eth9' --interface '0-10@eth10' --interface '0-11@eth11' --interface
'0-12@eth12' --interface '0-13@eth13' --interface '0-14@eth14'
--interface '0-15@eth15' --interface '0-16@eth16' --interface
'0-17@eth17' --interface '0-18@eth18' --interface '0-19@eth19'
--interface '0-20@eth20' --interface '0-21@eth21' --interface
'0-22@eth22' --interface '0-23@eth23' --interface '0-24@eth24'
--interface '0-25@eth25' --interface '0-26@eth26' --interface
'0-27@eth27' --interface '0-28@eth28' --interface '0-29@eth29'
--interface '0-30@eth30' --interface '0-31@eth31' --relax
"--test-params=thrift_server='10.3.147.253'"