### PR TITLE
modify Build PTF-SAIv2 infras

### DIFF
--- a/ptf/docs/ExampleCheckSonicVersionAndBuildSaiserverDocker.md
+++ b/ptf/docs/ExampleCheckSonicVersionAndBuildSaiserverDocker.md
@@ -1,6 +1,7 @@
 # Example: Check sonic version and build related saiserver docker
 *In this article, you will get known how to get a saiserver docker and get a builder to build saiserver binary*
 
+## Check sonic version
 1. Check SONiC version in a DUT
 **Old version might hit some issue caused by a related package upgrade, you can always use the latest tag of a major version(i.e major is 20201231) but notice the matching image version.**
    ```
@@ -12,7 +13,9 @@
    #Image build without tag
    SONiC Software Version: SONiC.master.39085-dirty-20210923.145659
    ```
-2.  Get the commit id from sonic-buildimage.
+
+## Build related saiserver docker
+1.  Get the commit id from sonic-buildimage.
 
       *ps. sonic-buildimage is a repository used to build sonic images and docker images. SAI is a submodule in sonic-buildimage(/sonic-buildimage/tree/master/src/sonic-sairedis). The commit id in sonic-buildimage can be used to get all the submodules for its submodule, like sai.*
 
@@ -23,15 +26,19 @@
    - Get commit id from tag.
 
       ```	
+      rm -rf ./sonic-buildimage
+      git clone https://github.com/Azure/sonic-buildimage.git
+      cd sonic-buildimage
+
       # git checkout tags/<tag> -b <branch>
       # Example:
       git checkout tags/20201231.39 -b richardyu/20201231-39
-      #check the commit id
+      # check the commit id
       git rev-list -n 1 20201231.39
       ```
    - Get commit id from docker image
       ```
-      #Get image name
+      # Get image name
       docker images
       REPOSITORY                                        TAG                                  IMAGE ID            CREATED             SIZE   
       ...   
@@ -63,7 +70,7 @@
 
    [GitHub - Azure/sonic-buildimage: Scripts which perform an installable binary image build for SONiC](https://github.com/Azure/sonic-buildimage)
 
-3. Start a local build
+2. Start a local build
    ```
    # Clean environment as needed
    make reset
@@ -79,8 +86,8 @@
    **You can get this build target by running commands like(adjust as needed): NOSTRETCH=y NOJESSIE=y ENABLE_SYNCD_RPC=y make list**
 
 
-4. Wait for the build process 
-5. In the end, you will get something like this, and prompt as below (inside docker)
+3. Wait for the build process 
+4. In the end, you will get something like this, and prompt as below (inside docker)
    ```
    # Check if thrift installed
    richardyu@a0363ed6ca36:/sonic$ thrift
@@ -88,7 +95,7 @@
 
    Use thrift -help for a list of options
    ```
-6. Keep this terminal and start another terminal, log in to the same host
+5. Keep this terminal and start another terminal, log in to the same host
  - Check the docker, the builder appears with the name sonic-slave-***, it is always the recently created one
    ```
    docker ps
@@ -102,8 +109,8 @@
    docker commit <docker_name> <docker_image>:<tag>
    docker commit condescending_lovelace saisever-builder-20201231-39:0.0.1
    ```
-7. Then, exit from the docker above (console as 'richardyu@e1df2df072c4'), you can get your buildout artifacts in folder `./target`, there also contains the logs and other accessories
-8. For building the saiserver binary, you can mount your local SAI repository to that docker and just start that docker for your building purpose.
+6. Then, exit from the docker above (console as 'richardyu@e1df2df072c4'), you can get your buildout artifacts in folder `./target`, there also contains the logs and other accessories
+7. For building the saiserver binary, you can mount your local SAI repository to that docker and just start that docker for your building purpose.
    ```
    # SAI repo is located inside the local /code folder
    docker run --name saisever-builder-20201231-39 -v  /code:/data -di saisever-builder-20201231-39:0.0.1 bash

--- a/ptf/docs/PTF-SAIv2Overview.md
+++ b/ptf/docs/PTF-SAIv2Overview.md
@@ -25,16 +25,8 @@ Besides, following the latter sections, we can also use other SONiC scripts to h
 ## Build PTF-SAIv2 infras leveraged by sonic-buildimage
 *In this part, we will build PTF-SAIv2 infras using sonic-buildimage.*
 
-1. Check the sonic image version and commit id: [Check SAI Header Version And SONiC Branch](ExampleCheckSonicVersionAndBuildSaiserverDocker.md)
-2. Reset the sonic-buildimage with the branch and commit id previous checked
-    ```
-    rm -rf ./sonic-buildimage
-    git clone https://github.com/Azure/sonic-buildimage.git
-    cd sonic-buildimage
-
-    git checkout <specific branch>
-    git reset --hard <specific commit id>
-    ```
+1. Check the sonic image version and commit id: [Check SAI Header Version And SONiC Branch](ExampleCheckSonicVersionAndBuildSaiserverDocker.md#check-sonic-version)
+2. Reset the sonic-buildimage with the branch and commit id previous checked: [Build Related Saiserver Docker](ExampleCheckSonicVersionAndBuildSaiserverDocker.md#build-related-saiserver-docker)
 3. Build PTF-SAIv2 infras 
     ```
     # Init env


### PR DESCRIPTION
## Description
Modify `Build PTF-SAIv2 infras leveraged by sonic-buildimage` in `PTF-SAIv2 Overview`.
- Split `Example: Check sonic version and build related saiserver docker` into two subtitles: `Check sonic version` and `Build related saiserver docker`.
- Link to the above two subtitles in `Build PTF-SAIv2 infras leveraged by sonic-buildimage`.


Signed-off-by: zhiyuanliang-ms <liangzy512@gmail.com>